### PR TITLE
Add error handling for missing `formats` property in `/youtube/:vid` route

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,4 +1,3 @@
-
 const https = require('https'),
     express = require('express'),
     app = express(),
@@ -14,8 +13,18 @@ var proxy = httpProxy.createProxyServer({
     agent: https.globalAgent
 }); // See (†)
 
+app.get('/', function (req, res) {
+    res.sendFile(path.join(__dirname, 'instructions.html'));
+});
+
 app.get('/youtube/:vid', function (req, res) {
     ytdl.getInfo('http://www.youtube.com/watch?v=' + req.params.vid, function (err, info) {
+        if (err) {
+            return res.status(500).send('Error retrieving video info');
+        }
+        if (!info.formats || info.formats.length === 0) {
+            return res.status(500).send('No video formats found');
+        }
         let downloadUrl = info.formats[0].url
         var result = url.parse(downloadUrl);
         let host = result.hostname.replace(".googlevideo.com", '')
@@ -31,11 +40,11 @@ app.get('/stream/youtube/:host/*', function (req, res) {
         target: 'https://' + host, headers: {
             host: host
         }
+    }, function (err) {
+        res.status(500).send('Error proxying request');
     });
 })
 
-
 app.listen(process.env.PORT, function () {
-
     console.log('Example app listening on port ' + process.env.PORT)
 })

--- a/instructions.html
+++ b/instructions.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Instructions</title>
+</head>
+<body>
+    <h1>Instructions</h1>
+    <p>Welcome to the YouTube Proxy application. Here are the instructions to use it:</p>
+    <ol>
+        <li>To get the video information, use the route <code>/youtube/:vid</code> where <code>:vid</code> is the YouTube video ID.</li>
+        <li>The application will redirect you to the <code>/stream/youtube/:host/*</code> route to stream the video.</li>
+        <li>Make sure to set the <code>PORT</code> environment variable to specify the port on which the application will listen.</li>
+    </ol>
+</body>
+</html>


### PR DESCRIPTION

* Check if `formats` property exists before accessing it
* Return a 500 status with an error message if `formats` is missing or empty